### PR TITLE
Add invoice URL generation helper and usage

### DIFF
--- a/lib/invoices.ts
+++ b/lib/invoices.ts
@@ -1,0 +1,11 @@
+export function generatePrintHeshUrl(transId: string): string {
+  const baseUrl = process.env.NEXT_PUBLIC_HYPAY_BASE_URL || 'https://pay.hyp.co.il/p/'
+  const masof = process.env.NEXT_PUBLIC_HYPAY_MASOF_ID || '4501961334'
+  const params = new URLSearchParams({
+    action: 'PrintHesh',
+    Masof: masof,
+    TransId: transId,
+    type: 'EZCOUNT'
+  })
+  return `${baseUrl}?${params.toString()}`
+}


### PR DESCRIPTION
## Summary
- add `generatePrintHeshUrl` helper for building Hypay invoice links
- update payment success handler to upsert invoices with link

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878860745e483208cc3fbcf33d1e3e1